### PR TITLE
Internal access declaration

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_vh.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_vh.sv
@@ -55,6 +55,12 @@ module tlul_adapter_vh
   output logic [ID_WIDTH-1:0]   int_id_o
 );
 
+  // The adapter distinguishes between two types of VH accesses: those going to an internal register
+  // file and those targeting OpenTitan registers, with the latter ones being translated into TLUL
+  // requests while the other requests are relayed to the internal register file.
+  logic internal_access;
+  assign internal_access = addr_i >= VH_REGISTER_ADDRESS_OFFSET;
+
   // Differentiate between two levels of acknowledgements:
   //  - `req_ack`: A host-to-device request is acknowledged by the device, meaning that the response
   //    is pending.
@@ -99,12 +105,6 @@ module tlul_adapter_vh
     // unused
     a_param: 3'h0
   };
-
-  // The adapter distinguishes between two types of VH accesses: those going to an internal register
-  // file and those targeting OpenTitan registers, with the latter ones being translated into TLUL
-  // requests while the other requests are relayed to the internal register file.
-  logic internal_access;
-  assign internal_access = addr_i >= VH_REGISTER_ADDRESS_OFFSET;
 
   // Accesses to device registers are acknowledged with the TLUL d-channel handshake.
   assign hld_o = !pending_q && internal_access && !int_hld_i ? 1'b0 :


### PR DESCRIPTION
Move declaration of the `internal_access` signal to remove access before declaration issues.
