### PR TITLE
[aes_gcm,sca] Add tests

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -20,6 +20,7 @@
 #include "sw/device/lib/testing/aes_testutils.h"
 #endif
 
+#include "aes_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 /**
@@ -57,6 +58,18 @@ enum {
    * measurements.
    */
   kBlockCtrMax = 8191,
+  /**
+   * Max. number of AAD or PTX blocks supported by the AES-GCM tests.
+   */
+  kMaxGcmBlocks = 4,
+  /**
+   * Number of cycles we are putting Ibex into sleep mode. In the meanwhile,
+   * AES-GCM executes and we are measuring the power consumption of the
+   * operation. The number of cycles were determined by using ibex_mcycle_read()
+   * between calling dif_aes_trigger() and waiting until the IDLE bit has been
+   * seen.
+   */
+  kIbexAesGcmSleepCycles = 5100,
 };
 
 /**
@@ -630,6 +643,264 @@ status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj) {
   return OK_STATUS();
 }
 
+static status_t trigger_aes_gcm(
+    dif_aes_key_share_t key, dif_aes_iv_t iv, dif_aes_data_t aad[kMaxGcmBlocks],
+    size_t aad_num_blocks, size_t aad_last_block_size,
+    dif_aes_data_t ptx[kMaxGcmBlocks], size_t ptx_num_blocks,
+    size_t ptx_last_block_size, dif_aes_data_t *ctx, dif_aes_data_t *tag,
+    aes_sca_gcm_triggers_t trigger) {
+  // AES GCM configuration used for this test.
+  dif_aes_transaction_t transaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeGcm,
+      .key_len = kDifAesKey128,
+      .key_provider = kDifAesKeySoftwareProvided,
+      .manual_operation = kDifAesManualOperationManual,
+      .mask_reseeding = kDifAesReseedPer8kBlock,
+      .reseed_on_key_change = false,
+      .force_masks = false,
+      .ctrl_aux_lock = false,
+  };
+
+  // Write the initial key share, IV and data in CSRs.
+  TRY(dif_aes_start(&aes, &transaction, &key, &iv));
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
+                                kIbexAesGcmSleepCycles * 2);
+  // Encrypt all-zero block.
+  aes_manual_trigger();
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
+                                kIbexAesGcmSleepCycles * 2);
+  // Encrypt initial counter block.
+  if (trigger.triggers[0]) {
+    // In the FPGA mode, the AES automatically raises the trigger signal. For
+    // the other mode, the pentest_call_and_sleep function manually raises the
+    // trigger pin.
+    pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
+                           !fpga_mode, false);
+  } else {
+    aes_manual_trigger();
+  }
+
+  // Process the AAD blocks.
+  // For the first block, put the AES-GCM into the AAD phase.
+  size_t valid_bytes = 16;
+  if (aad_num_blocks == 1) {
+    valid_bytes = aad_last_block_size;
+  }
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_set_gcm_phase(&aes, AES_CTRL_GCM_SHADOWED_PHASE_VALUE_GCM_AAD,
+                            valid_bytes));
+  for (size_t it = 0; it < aad_num_blocks - 1; it++) {
+    AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
+                                  kIbexAesGcmSleepCycles * 2);
+    TRY(dif_aes_load_data(&aes, aad[it]));
+    if (trigger.triggers[1] && trigger.block == it) {
+      // In the FPGA mode, the AES automatically raises the trigger signal. For
+      // the other mode, the pentest_call_and_sleep function manually raises the
+      // trigger pin.
+      pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
+                             !fpga_mode, false);
+    } else {
+      aes_manual_trigger();
+    }
+  }
+
+  // For the last block, check if the block size is smaller than 16 bytes. Then
+  // we need to again put AES-GCM into the AAD phase with the block size.
+  if (aad_num_blocks != 1 && aad_last_block_size != 16) {
+    AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
+                                  kIbexAesGcmSleepCycles * 2);
+    TRY(dif_aes_set_gcm_phase(&aes, AES_CTRL_GCM_SHADOWED_PHASE_VALUE_GCM_AAD,
+                              aad_last_block_size));
+  }
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_load_data(&aes, aad[aad_num_blocks - 1]));
+  if (trigger.triggers[1] && trigger.block == aad_num_blocks - 1) {
+    // In the FPGA mode, the AES automatically raises the trigger signal. For
+    // the other mode, the pentest_call_and_sleep function manually raises the
+    // trigger pin.
+    pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
+                           !fpga_mode, false);
+  } else {
+    aes_manual_trigger();
+  }
+
+  // Process the PTX blocks.
+  // For the first block, put the AES-GCM into the TEXT phase.
+  valid_bytes = 16;
+  if (ptx_num_blocks == 1) {
+    valid_bytes = ptx_last_block_size;
+  }
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_set_gcm_phase(&aes, AES_CTRL_GCM_SHADOWED_PHASE_VALUE_GCM_TEXT,
+                            valid_bytes));
+  for (size_t it = 0; it < ptx_num_blocks - 1; it++) {
+    AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
+                                  kIbexAesGcmSleepCycles * 2);
+    TRY(dif_aes_load_data(&aes, ptx[it]));
+    if (trigger.triggers[2] && trigger.block == it) {
+      // In the FPGA mode, the AES automatically raises the trigger signal. For
+      // the other mode, the pentest_call_and_sleep function manually raises the
+      // trigger pin.
+      pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
+                             !fpga_mode, false);
+    } else {
+      aes_manual_trigger();
+    }
+  }
+  // For the last block, check if the block size is smaller than 16 bytes. Then
+  // we need to again put AES-GCM into the TEXT phase with the block size.
+  if (ptx_num_blocks != 1 && ptx_last_block_size != 16) {
+    AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
+                                  kIbexAesGcmSleepCycles * 2);
+    TRY(dif_aes_set_gcm_phase(&aes, AES_CTRL_GCM_SHADOWED_PHASE_VALUE_GCM_TEXT,
+                              ptx_last_block_size));
+  }
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_load_data(&aes, ptx[ptx_num_blocks - 1]));
+  if (trigger.triggers[2] && trigger.block == ptx_num_blocks - 1) {
+    // In the FPGA mode, the AES automatically raises the trigger signal. For
+    // the other mode, the pentest_call_and_sleep function manually raises the
+    // trigger pin.
+    pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
+                           !fpga_mode, false);
+  } else {
+    aes_manual_trigger();
+  }
+
+  // Read the last CTX block from the AES.
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusOutputValid, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_read_output(&aes, ctx));
+
+  // Generate tag.
+  size_t ptx_total_bytes = (ptx_num_blocks - 1) * 16 + ptx_last_block_size;
+  size_t aad_total_bytes = (aad_num_blocks - 1) * 16 + aad_last_block_size;
+  uint64_t len_ptx = ptx_total_bytes * 8;
+  uint64_t len_aad = aad_total_bytes * 8;
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_set_gcm_phase(&aes, AES_CTRL_GCM_SHADOWED_PHASE_VALUE_GCM_TAG,
+                            16));
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_load_gcm_tag_len(&aes, len_ptx, len_aad));
+  aes_manual_trigger();
+
+  // Read the TAG block from the AES.
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusOutputValid, true,
+                                kIbexAesGcmSleepCycles * 2);
+  TRY(dif_aes_read_output(&aes, tag));
+
+  return OK_STATUS();
+}
+
+status_t handle_aes_sca_gcm_single_encrypt(ujson_t *uj) {
+  // Receive the AES-GCM input data over uJSON.
+  aes_sca_gcm_triggers_t uj_triggers;
+  aes_sca_block_t uj_iv;
+  aes_sca_key_t uj_key;
+  aes_sca_num_blocks_t uj_aad_blocks;
+  aes_sca_num_blocks_t uj_ptx_blocks;
+  aes_sca_block_t uj_aad[kMaxGcmBlocks];
+  aes_sca_block_t uj_ptx[kMaxGcmBlocks];
+  // Get the trigger configuration.
+  // uj_triggers.triggers[0] = True/False - process initial counter block.
+  // uj_triggers.triggers[1] = True/False - process AAD blocks.
+  // uj_triggers.triggers[2] = True/False - process PTX blocks.
+  // uj_triggers.block = int - which AAD or PTX block is captured?
+  TRY(ujson_deserialize_aes_sca_gcm_triggers_t(uj, &uj_triggers));
+  // Get IV and KEY.
+  TRY(ujson_deserialize_aes_sca_block_t(uj, &uj_iv));
+  TRY(ujson_deserialize_aes_sca_key_t(uj, &uj_key));
+  // Get number of AAD and PTX blocks we are expecting.
+  TRY(ujson_deserialize_aes_sca_num_blocks_t(uj, &uj_aad_blocks));
+  TRY(ujson_deserialize_aes_sca_num_blocks_t(uj, &uj_ptx_blocks));
+  if (uj_aad_blocks.num_blocks > kMaxGcmBlocks ||
+      uj_ptx_blocks.num_blocks > kMaxGcmBlocks) {
+    return ABORTED();
+  }
+  // Fetch all AAD blocks.
+  for (size_t it = 0; it < uj_aad_blocks.num_blocks; it++) {
+    TRY(ujson_deserialize_aes_sca_block_t(uj, &uj_aad[it]));
+  }
+  // Fetch all PTX blocks.
+  for (size_t it = 0; it < uj_ptx_blocks.num_blocks; it++) {
+    TRY(ujson_deserialize_aes_sca_block_t(uj, &uj_ptx[it]));
+  }
+
+  // Prepare AES IV.
+  dif_aes_iv_t aes_iv;
+  memset(aes_iv.iv, 0, 16);
+  memcpy(aes_iv.iv, uj_iv.block, uj_iv.num_valid_bytes);
+
+  // Prepare keys.
+  dif_aes_key_share_t key;
+  memset(key.share0, 0, sizeof(key.share0));
+  memset(key.share1, 0, sizeof(key.share1));
+
+  // Mask the provided key.
+  for (int i = 0; i < uj_key.key_length / 4; ++i) {
+    key.share1[i] = pentest_non_linear_layer(
+        pentest_linear_layer(pentest_next_lfsr(1, kPentestLfsrMasking)));
+    key.share0[i] = *((uint32_t *)uj_key.key + i) ^ key.share1[i];
+  }
+  // Provide random shares for unused key bits.
+  for (size_t i = uj_key.key_length / 4; i < kAesKeyLengthMax / 4; ++i) {
+    key.share1[i] =
+        pentest_non_linear_layer(pentest_next_lfsr(1, kPentestLfsrMasking));
+    key.share0[i] =
+        pentest_non_linear_layer(pentest_next_lfsr(1, kPentestLfsrMasking));
+  }
+
+  // Prepare the AAD.
+  dif_aes_data_t aes_aad[kMaxGcmBlocks];
+  size_t aes_aad_last_block_size = 0;
+  for (size_t it = 0; it < uj_aad_blocks.num_blocks; it++) {
+    memset(aes_aad[it].data, 0, sizeof(aes_aad[it].data));
+    memcpy(aes_aad[it].data, uj_aad[it].block, uj_aad[it].num_valid_bytes);
+    aes_aad_last_block_size = uj_aad[it].num_valid_bytes;
+  }
+
+  // Prepare the plaintext.
+  dif_aes_data_t aes_ptx[kMaxGcmBlocks];
+  size_t aes_ptx_last_block_size = 0;
+  for (size_t it = 0; it < uj_ptx_blocks.num_blocks; it++) {
+    memset(aes_ptx[it].data, 0, sizeof(aes_ptx[it].data));
+    memcpy(aes_ptx[it].data, uj_ptx[it].block, uj_ptx[it].num_valid_bytes);
+    aes_ptx_last_block_size = uj_ptx[it].num_valid_bytes;
+  }
+
+  // Trigger the AES GCM operation.
+  dif_aes_data_t aes_ctx;
+  dif_aes_data_t aes_tag;
+  TRY(trigger_aes_gcm(key, aes_iv, aes_aad, uj_aad_blocks.num_blocks,
+                      aes_aad_last_block_size, aes_ptx,
+                      uj_ptx_blocks.num_blocks, aes_ptx_last_block_size,
+                      &aes_ctx, &aes_tag, uj_triggers));
+
+  // Send last CTX and TAG back to host.
+  aes_sca_block_t uj_ctx;
+  aes_sca_block_t uj_tag;
+
+  uj_ctx.num_valid_bytes = 16;
+  memset(uj_ctx.block, 0, sizeof(uj_ctx.block));
+  memcpy(uj_ctx.block, (uint8_t *)aes_ctx.data, uj_ctx.num_valid_bytes);
+
+  uj_tag.num_valid_bytes = 16;
+  memset(uj_tag.block, 0, sizeof(uj_tag.block));
+  memcpy(uj_tag.block, (uint8_t *)aes_tag.data, uj_tag.num_valid_bytes);
+
+  RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_ctx);
+  RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_tag);
+
+  return OK_STATUS();
+}
+
 status_t handle_aes_pentest_init(ujson_t *uj) {
   // Read mode. FPGA or discrete.
   aes_sca_fpga_mode_t uj_data;
@@ -773,6 +1044,8 @@ status_t handle_aes_sca(ujson_t *uj) {
       return handle_aes_sca_fvsr_key_set(uj);
     case kAesScaSubcommandFvsrKeyStartBatchGenerate:
       return handle_aes_sca_fvsr_key_start_batch_generate(uj);
+    case kAesScaSubcommandGcmSingleEncrypt:
+      return handle_aes_sca_gcm_single_encrypt(uj);
     case kAesScaSubcommandInit:
       return handle_aes_pentest_init(uj);
     case kAesScaSubcommandKeySet:

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -789,7 +789,15 @@ static status_t trigger_aes_gcm(
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
                                 kIbexAesGcmSleepCycles * 2);
   TRY(dif_aes_load_gcm_tag_len(&aes, len_ptx, len_aad));
-  aes_manual_trigger();
+  if (trigger.triggers[3]) {
+    // In the FPGA mode, the AES automatically raises the trigger signal. For
+    // the other mode, the pentest_call_and_sleep function manually raises the
+    // trigger pin.
+    pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
+                           !fpga_mode, false);
+  } else {
+    aes_manual_trigger();
+  }
 
   // Read the TAG block from the AES.
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusOutputValid, true,
@@ -818,6 +826,7 @@ status_t handle_aes_sca_gcm_fvsr_batch(ujson_t *uj) {
   // uj_triggers.triggers[0] = True/False - process initial counter block.
   // uj_triggers.triggers[1] = True/False - process AAD blocks.
   // uj_triggers.triggers[2] = True/False - process PTX blocks.
+  // uj_triggers.triggers[3] = True/False - process TAG block.
   // uj_triggers.block = int - which AAD or PTX block is captured?
   TRY(ujson_deserialize_aes_sca_gcm_triggers_t(uj, &uj_triggers));
   // Get fixed IV and fixed KEY.
@@ -957,6 +966,7 @@ status_t handle_aes_sca_gcm_single_encrypt(ujson_t *uj) {
   // uj_triggers.triggers[0] = True/False - process initial counter block.
   // uj_triggers.triggers[1] = True/False - process AAD blocks.
   // uj_triggers.triggers[2] = True/False - process PTX blocks.
+  // uj_triggers.triggers[3] = True/False - process TAG block.
   // uj_triggers.block = int - which AAD or PTX block is captured?
   TRY(ujson_deserialize_aes_sca_gcm_triggers_t(uj, &uj_triggers));
   // Get IV and KEY.

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -67,9 +67,10 @@ enum {
    * AES-GCM executes and we are measuring the power consumption of the
    * operation. The number of cycles were determined by using ibex_mcycle_read()
    * between calling dif_aes_trigger() and waiting until the IDLE bit has been
-   * seen.
+   * seen. Here, up to 300 cycles were measured. Moreover, we are using a start
+   * trigger delay of 320.
    */
-  kIbexAesGcmSleepCycles = 5100,
+  kIbexAesGcmSleepCycles = 1000,
 };
 
 /**

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -914,8 +914,10 @@ status_t handle_aes_sca_gcm_fvsr_batch(ujson_t *uj) {
 
   // Trigger the AES GCM operation.
   dif_aes_data_t aes_tag_acc;
-  memset(aes_tag_acc.data, 0,
-         sizeof(aes_tag_acc.data[0] * ARRAYSIZE(aes_tag_acc.data)));
+  aes_tag_acc.data[0] = 0;
+  aes_tag_acc.data[1] = 0;
+  aes_tag_acc.data[2] = 0;
+  aes_tag_acc.data[3] = 0;
   for (size_t it = 0; it < uj_num_ops.num_batch_ops; it++) {
     dif_aes_data_t aes_tag;
     TRY(trigger_aes_gcm(key_fvsr[it], aes_iv_fvsr[it], aes_aad,

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -799,6 +799,151 @@ static status_t trigger_aes_gcm(
   return OK_STATUS();
 }
 
+status_t handle_aes_sca_gcm_fvsr_batch(ujson_t *uj) {
+  // Receive the AES-GCM input data over uJSON.
+  aes_sca_num_ops_t uj_num_ops;
+  aes_sca_gcm_triggers_t uj_triggers;
+  aes_sca_block_t uj_iv;
+  aes_sca_key_t uj_key;
+  aes_sca_num_blocks_t uj_aad_blocks;
+  aes_sca_num_blocks_t uj_ptx_blocks;
+  aes_sca_block_t uj_aad[kMaxGcmBlocks];
+  aes_sca_block_t uj_ptx[kMaxGcmBlocks];
+  // Get number of batch iterations.
+  TRY(ujson_deserialize_aes_sca_num_ops_t(uj, &uj_num_ops));
+  if (uj_num_ops.num_batch_ops > kNumBatchOpsMax) {
+    return OUT_OF_RANGE();
+  }
+  // Get the trigger configuration.
+  // uj_triggers.triggers[0] = True/False - process initial counter block.
+  // uj_triggers.triggers[1] = True/False - process AAD blocks.
+  // uj_triggers.triggers[2] = True/False - process PTX blocks.
+  // uj_triggers.block = int - which AAD or PTX block is captured?
+  TRY(ujson_deserialize_aes_sca_gcm_triggers_t(uj, &uj_triggers));
+  // Get fixed IV and fixed KEY.
+  TRY(ujson_deserialize_aes_sca_block_t(uj, &uj_iv));
+  TRY(ujson_deserialize_aes_sca_key_t(uj, &uj_key));
+  // Get number of AAD and PTX blocks we are expecting.
+  TRY(ujson_deserialize_aes_sca_num_blocks_t(uj, &uj_aad_blocks));
+  TRY(ujson_deserialize_aes_sca_num_blocks_t(uj, &uj_ptx_blocks));
+  if (uj_aad_blocks.num_blocks > kMaxGcmBlocks ||
+      uj_ptx_blocks.num_blocks > kMaxGcmBlocks) {
+    return ABORTED();
+  }
+  // Fetch all AAD blocks.
+  for (size_t it = 0; it < uj_aad_blocks.num_blocks; it++) {
+    TRY(ujson_deserialize_aes_sca_block_t(uj, &uj_aad[it]));
+  }
+  // Fetch all PTX blocks.
+  for (size_t it = 0; it < uj_ptx_blocks.num_blocks; it++) {
+    TRY(ujson_deserialize_aes_sca_block_t(uj, &uj_ptx[it]));
+  }
+
+  // Prepare fixed AES IV.
+  dif_aes_iv_t aes_iv_fixed;
+  memset(aes_iv_fixed.iv, 0, 16);
+  memcpy(aes_iv_fixed.iv, uj_iv.block, uj_iv.num_valid_bytes);
+
+  // Generate Fvsr AES IV & key set.
+  dif_aes_iv_t aes_iv_fvsr[kNumBatchOpsMax];
+  uint8_t batch_keys[kNumBatchOpsMax][kAesKeyLength];
+  bool sample_fixed = true;
+  for (size_t it = 0; it < uj_num_ops.num_batch_ops; it++) {
+    memset(aes_iv_fvsr[it].iv, 0, 16);
+    memset(batch_keys[it], 0, kAesKeyLength);
+    if (sample_fixed) {
+      memcpy(aes_iv_fvsr[it].iv, aes_iv_fixed.iv, uj_iv.num_valid_bytes);
+      memcpy(batch_keys[it], uj_key.key, uj_key.key_length);
+    } else {
+      // Generate random IV.
+      uint8_t rand_iv[16];
+      prng_rand_bytes(rand_iv, 16);
+      memcpy(aes_iv_fvsr[it].iv, rand_iv, uj_iv.num_valid_bytes);
+      // Generate random key.
+      prng_rand_bytes(batch_keys[it], uj_key.key_length);
+    }
+    sample_fixed = prng_rand_uint32() & 0x1;
+  }
+
+  // Prepare batch key structure.
+  dif_aes_key_share_t key_fvsr[kNumBatchOpsMax];
+  for (size_t it = 0; it < uj_num_ops.num_batch_ops; it++) {
+    memset(key_fvsr[it].share0, 0, sizeof(key_fvsr[it].share0));
+    memset(key_fvsr[it].share1, 0, sizeof(key_fvsr[it].share1));
+
+    // Mask the provided key.
+    for (int i = 0; i < uj_key.key_length / 4; ++i) {
+      key_fvsr[it].share1[i] = pentest_non_linear_layer(
+          pentest_linear_layer(pentest_next_lfsr(1, kPentestLfsrMasking)));
+      key_fvsr[it].share0[i] =
+          *((uint32_t *)batch_keys[it] + i) ^ key_fvsr[it].share1[i];
+    }
+    // Provide random shares for unused key bits.
+    for (size_t i = uj_key.key_length / 4; i < kAesKeyLengthMax / 4; ++i) {
+      key_fvsr[it].share1[i] =
+          pentest_non_linear_layer(pentest_next_lfsr(1, kPentestLfsrMasking));
+      key_fvsr[it].share0[i] =
+          pentest_non_linear_layer(pentest_next_lfsr(1, kPentestLfsrMasking));
+    }
+  }
+
+  // Prepare the fixed AAD.
+  dif_aes_data_t aes_aad[kMaxGcmBlocks];
+  size_t aes_aad_last_block_size = 0;
+  for (size_t it = 0; it < uj_aad_blocks.num_blocks; it++) {
+    memset(aes_aad[it].data, 0, sizeof(aes_aad[it].data));
+    memcpy(aes_aad[it].data, uj_aad[it].block, uj_aad[it].num_valid_bytes);
+    aes_aad_last_block_size = uj_aad[it].num_valid_bytes;
+  }
+
+  // Prepare the fixed plaintext.
+  dif_aes_data_t aes_ptx[kMaxGcmBlocks];
+  size_t aes_ptx_last_block_size = 0;
+  for (size_t it = 0; it < uj_ptx_blocks.num_blocks; it++) {
+    memset(aes_ptx[it].data, 0, sizeof(aes_ptx[it].data));
+    memcpy(aes_ptx[it].data, uj_ptx[it].block, uj_ptx[it].num_valid_bytes);
+    aes_ptx_last_block_size = uj_ptx[it].num_valid_bytes;
+  }
+
+  // Trigger the AES GCM operation.
+  dif_aes_data_t aes_ctx_acc;
+  dif_aes_data_t aes_tag_acc;
+  memset(aes_ctx_acc.data, 0,
+         sizeof(aes_ctx_acc.data[0] * ARRAYSIZE(aes_ctx_acc.data)));
+  memset(aes_tag_acc.data, 0,
+         sizeof(aes_tag_acc.data[0] * ARRAYSIZE(aes_tag_acc.data)));
+  for (size_t it = 0; it < uj_num_ops.num_batch_ops; it++) {
+    dif_aes_data_t aes_ctx;
+    dif_aes_data_t aes_tag;
+    TRY(trigger_aes_gcm(
+        key_fvsr[it], aes_iv_fvsr[it], aes_aad, uj_aad_blocks.num_blocks,
+        aes_aad_last_block_size, aes_ptx, uj_ptx_blocks.num_blocks,
+        aes_ptx_last_block_size, &aes_ctx, &aes_tag, uj_triggers));
+    // Accumulate (i.e., XOR) TAG and CTX for sending back to host.
+    for (size_t i = 0; i < ARRAYSIZE(aes_ctx_acc.data); i++) {
+      aes_ctx_acc.data[i] ^= aes_ctx.data[i];
+      aes_tag_acc.data[i] ^= aes_tag.data[i];
+    }
+  }
+
+  // Send accumulated CTX and TAG back to host.
+  aes_sca_block_t uj_ctx;
+  aes_sca_block_t uj_tag;
+
+  uj_ctx.num_valid_bytes = 16;
+  memset(uj_ctx.block, 0, sizeof(uj_ctx.block));
+  memcpy(uj_ctx.block, (uint8_t *)aes_ctx_acc.data, uj_ctx.num_valid_bytes);
+
+  uj_tag.num_valid_bytes = 16;
+  memset(uj_tag.block, 0, sizeof(uj_tag.block));
+  memcpy(uj_tag.block, (uint8_t *)aes_tag_acc.data, uj_tag.num_valid_bytes);
+
+  RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_ctx);
+  RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_tag);
+
+  return OK_STATUS();
+}
+
 status_t handle_aes_sca_gcm_single_encrypt(ujson_t *uj) {
   // Receive the AES-GCM input data over uJSON.
   aes_sca_gcm_triggers_t uj_triggers;
@@ -1044,6 +1189,8 @@ status_t handle_aes_sca(ujson_t *uj) {
       return handle_aes_sca_fvsr_key_set(uj);
     case kAesScaSubcommandFvsrKeyStartBatchGenerate:
       return handle_aes_sca_fvsr_key_start_batch_generate(uj);
+    case kAesScaSubcommandGcmFvsrBatch:
+      return handle_aes_sca_gcm_fvsr_batch(uj);
     case kAesScaSubcommandGcmSingleEncrypt:
       return handle_aes_sca_gcm_single_encrypt(uj);
     case kAesScaSubcommandInit:

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -653,7 +653,7 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
                                 size_t ptx_last_block_size, dif_aes_data_t *tag,
                                 aes_sca_gcm_triggers_t trigger) {
   // AES GCM configuration used for this test.
-  dif_aes_transaction_t transaction = {
+  dif_aes_transaction_t transaction_gcm = {
       .operation = kDifAesOperationEncrypt,
       .mode = kDifAesModeGcm,
       .key_len = kDifAesKey128,
@@ -661,12 +661,12 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
       .manual_operation = kDifAesManualOperationManual,
       .mask_reseeding = kDifAesReseedPer8kBlock,
       .reseed_on_key_change = false,
-      .force_masks = false,
+      .force_masks = transaction.force_masks,
       .ctrl_aux_lock = false,
   };
 
   // Write the initial key share, IV and data in CSRs.
-  TRY(dif_aes_start(&aes, &transaction, &key, &iv));
+  TRY(dif_aes_start(&aes, &transaction_gcm, &key, &iv));
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
                                 kIbexAesGcmSleepCycles * 2);
   // Encrypt all-zero block.
@@ -678,8 +678,14 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
     // In the FPGA mode, the AES automatically raises the trigger signal. For
     // the other mode, the pentest_call_and_sleep function manually raises the
     // trigger pin.
+    if (fpga_mode) {
+      pentest_set_trigger_high();
+    }
     pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
                            !fpga_mode, false);
+    if (fpga_mode) {
+      pentest_set_trigger_low();
+    }
   } else {
     aes_manual_trigger();
   }
@@ -702,8 +708,14 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
       // In the FPGA mode, the AES automatically raises the trigger signal. For
       // the other mode, the pentest_call_and_sleep function manually raises the
       // trigger pin.
+      if (fpga_mode) {
+        pentest_set_trigger_high();
+      }
       pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
                              !fpga_mode, false);
+      if (fpga_mode) {
+        pentest_set_trigger_low();
+      }
     } else {
       aes_manual_trigger();
     }
@@ -724,8 +736,14 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
     // In the FPGA mode, the AES automatically raises the trigger signal. For
     // the other mode, the pentest_call_and_sleep function manually raises the
     // trigger pin.
+    if (fpga_mode) {
+      pentest_set_trigger_high();
+    }
     pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
                            !fpga_mode, false);
+    if (fpga_mode) {
+      pentest_set_trigger_low();
+    }
   } else {
     aes_manual_trigger();
   }
@@ -748,8 +766,14 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
       // In the FPGA mode, the AES automatically raises the trigger signal. For
       // the other mode, the pentest_call_and_sleep function manually raises the
       // trigger pin.
+      if (fpga_mode) {
+        pentest_set_trigger_high();
+      }
       pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
                              !fpga_mode, false);
+      if (fpga_mode) {
+        pentest_set_trigger_low();
+      }
     } else {
       aes_manual_trigger();
     }
@@ -769,8 +793,14 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
     // In the FPGA mode, the AES automatically raises the trigger signal. For
     // the other mode, the pentest_call_and_sleep function manually raises the
     // trigger pin.
+    if (fpga_mode) {
+      pentest_set_trigger_high();
+    }
     pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
                            !fpga_mode, false);
+    if (fpga_mode) {
+      pentest_set_trigger_low();
+    }
   } else {
     aes_manual_trigger();
   }
@@ -791,8 +821,14 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
     // In the FPGA mode, the AES automatically raises the trigger signal. For
     // the other mode, the pentest_call_and_sleep function manually raises the
     // trigger pin.
+    if (fpga_mode) {
+      pentest_set_trigger_high();
+    }
     pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
                            !fpga_mode, false);
+    if (fpga_mode) {
+      pentest_set_trigger_low();
+    }
   } else {
     aes_manual_trigger();
   }

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -697,11 +697,25 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
                                 kIbexAesGcmSleepCycles * 2);
   // Encrypt all-zero block.
-  aes_manual_trigger();
+  if (trigger.triggers[0]) {
+    // In the FPGA mode, the AES automatically raises the trigger signal. For
+    // the other mode, the pentest_call_and_sleep function manually raises the
+    // trigger pin.
+    if (fpga_mode) {
+      pentest_set_trigger_high();
+    }
+    pentest_call_and_sleep(aes_manual_trigger, kIbexAesGcmSleepCycles,
+                           !fpga_mode, false);
+    if (fpga_mode) {
+      pentest_set_trigger_low();
+    }
+  } else {
+    aes_manual_trigger();
+  }
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true,
                                 kIbexAesGcmSleepCycles * 2);
   // Encrypt initial counter block.
-  if (trigger.triggers[0]) {
+  if (trigger.triggers[1]) {
     // In the FPGA mode, the AES automatically raises the trigger signal. For
     // the other mode, the pentest_call_and_sleep function manually raises the
     // trigger pin.
@@ -731,7 +745,7 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
     AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
                                   kIbexAesGcmSleepCycles * 2);
     TRY(dif_aes_load_data(&aes, aad[it]));
-    if (trigger.triggers[1] && trigger.block == it) {
+    if (trigger.triggers[2] && trigger.block == it) {
       // In the FPGA mode, the AES automatically raises the trigger signal. For
       // the other mode, the pentest_call_and_sleep function manually raises the
       // trigger pin.
@@ -759,7 +773,7 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
                                 kIbexAesGcmSleepCycles * 2);
   TRY(dif_aes_load_data(&aes, aad[aad_num_blocks - 1]));
-  if (trigger.triggers[1] && trigger.block == aad_num_blocks - 1) {
+  if (trigger.triggers[2] && trigger.block == aad_num_blocks - 1) {
     // In the FPGA mode, the AES automatically raises the trigger signal. For
     // the other mode, the pentest_call_and_sleep function manually raises the
     // trigger pin.
@@ -789,7 +803,7 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
     AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
                                   kIbexAesGcmSleepCycles * 2);
     TRY(dif_aes_load_data(&aes, ptx[it]));
-    if (trigger.triggers[2] && trigger.block == it) {
+    if (trigger.triggers[3] && trigger.block == it) {
       // In the FPGA mode, the AES automatically raises the trigger signal. For
       // the other mode, the pentest_call_and_sleep function manually raises the
       // trigger pin.
@@ -816,7 +830,7 @@ static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true,
                                 kIbexAesGcmSleepCycles * 2);
   TRY(dif_aes_load_data(&aes, ptx[ptx_num_blocks - 1]));
-  if (trigger.triggers[2] && trigger.block == ptx_num_blocks - 1) {
+  if (trigger.triggers[3] && trigger.block == ptx_num_blocks - 1) {
     // In the FPGA mode, the AES automatically raises the trigger signal. For
     // the other mode, the pentest_call_and_sleep function manually raises the
     // trigger pin.
@@ -884,10 +898,11 @@ status_t handle_aes_sca_gcm_fvsr_batch(ujson_t *uj) {
     return OUT_OF_RANGE();
   }
   // Get the trigger configuration.
-  // uj_triggers.triggers[0] = True/False - process initial counter block.
-  // uj_triggers.triggers[1] = True/False - process AAD blocks.
-  // uj_triggers.triggers[2] = True/False - process PTX blocks.
-  // uj_triggers.triggers[3] = True/False - process TAG block.
+  // uj_triggers.triggers[0] = True/False - process all-zero block.
+  // uj_triggers.triggers[1] = True/False - process initial counter block.
+  // uj_triggers.triggers[2] = True/False - process AAD blocks.
+  // uj_triggers.triggers[3] = True/False - process PTX blocks.
+  // uj_triggers.triggers[4] = True/False - process TAG block.
   // uj_triggers.block = int - which AAD or PTX block is captured?
   TRY(ujson_deserialize_aes_sca_gcm_triggers_t(uj, &uj_triggers));
   // Get fixed IV and fixed KEY.
@@ -1014,10 +1029,11 @@ status_t handle_aes_sca_gcm_single_encrypt(ujson_t *uj) {
   aes_sca_block_t uj_aad[kMaxGcmBlocks];
   aes_sca_block_t uj_ptx[kMaxGcmBlocks];
   // Get the trigger configuration.
-  // uj_triggers.triggers[0] = True/False - process initial counter block.
-  // uj_triggers.triggers[1] = True/False - process AAD blocks.
-  // uj_triggers.triggers[2] = True/False - process PTX blocks.
-  // uj_triggers.triggers[3] = True/False - process TAG block.
+  // uj_triggers.triggers[0] = True/False - process all-zero block.
+  // uj_triggers.triggers[1] = True/False - process initial counter block.
+  // uj_triggers.triggers[2] = True/False - process AAD blocks.
+  // uj_triggers.triggers[3] = True/False - process PTX blocks.
+  // uj_triggers.triggers[4] = True/False - process TAG block.
   // uj_triggers.block = int - which AAD or PTX block is captured?
   TRY(ujson_deserialize_aes_sca_gcm_triggers_t(uj, &uj_triggers));
   // Get IV and KEY.

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -643,12 +643,14 @@ status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj) {
   return OK_STATUS();
 }
 
-static status_t trigger_aes_gcm(
-    dif_aes_key_share_t key, dif_aes_iv_t iv, dif_aes_data_t aad[kMaxGcmBlocks],
-    size_t aad_num_blocks, size_t aad_last_block_size,
-    dif_aes_data_t ptx[kMaxGcmBlocks], size_t ptx_num_blocks,
-    size_t ptx_last_block_size, dif_aes_data_t *ctx, dif_aes_data_t *tag,
-    aes_sca_gcm_triggers_t trigger) {
+static status_t trigger_aes_gcm(dif_aes_key_share_t key, dif_aes_iv_t iv,
+                                dif_aes_data_t aad[kMaxGcmBlocks],
+                                size_t aad_num_blocks,
+                                size_t aad_last_block_size,
+                                dif_aes_data_t ptx[kMaxGcmBlocks],
+                                size_t ptx_num_blocks,
+                                size_t ptx_last_block_size, dif_aes_data_t *tag,
+                                aes_sca_gcm_triggers_t trigger) {
   // AES GCM configuration used for this test.
   dif_aes_transaction_t transaction = {
       .operation = kDifAesOperationEncrypt,
@@ -771,11 +773,6 @@ static status_t trigger_aes_gcm(
   } else {
     aes_manual_trigger();
   }
-
-  // Read the last CTX block from the AES.
-  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusOutputValid, true,
-                                kIbexAesGcmSleepCycles * 2);
-  TRY(dif_aes_read_output(&aes, ctx));
 
   // Generate tag.
   size_t ptx_total_bytes = (ptx_num_blocks - 1) * 16 + ptx_last_block_size;
@@ -915,39 +912,27 @@ status_t handle_aes_sca_gcm_fvsr_batch(ujson_t *uj) {
   }
 
   // Trigger the AES GCM operation.
-  dif_aes_data_t aes_ctx_acc;
   dif_aes_data_t aes_tag_acc;
-  memset(aes_ctx_acc.data, 0,
-         sizeof(aes_ctx_acc.data[0] * ARRAYSIZE(aes_ctx_acc.data)));
   memset(aes_tag_acc.data, 0,
          sizeof(aes_tag_acc.data[0] * ARRAYSIZE(aes_tag_acc.data)));
   for (size_t it = 0; it < uj_num_ops.num_batch_ops; it++) {
-    dif_aes_data_t aes_ctx;
     dif_aes_data_t aes_tag;
-    TRY(trigger_aes_gcm(
-        key_fvsr[it], aes_iv_fvsr[it], aes_aad, uj_aad_blocks.num_blocks,
-        aes_aad_last_block_size, aes_ptx, uj_ptx_blocks.num_blocks,
-        aes_ptx_last_block_size, &aes_ctx, &aes_tag, uj_triggers));
-    // Accumulate (i.e., XOR) TAG and CTX for sending back to host.
-    for (size_t i = 0; i < ARRAYSIZE(aes_ctx_acc.data); i++) {
-      aes_ctx_acc.data[i] ^= aes_ctx.data[i];
+    TRY(trigger_aes_gcm(key_fvsr[it], aes_iv_fvsr[it], aes_aad,
+                        uj_aad_blocks.num_blocks, aes_aad_last_block_size,
+                        aes_ptx, uj_ptx_blocks.num_blocks,
+                        aes_ptx_last_block_size, &aes_tag, uj_triggers));
+    // Accumulate (i.e., XOR) TAG for sending back to host.
+    for (size_t i = 0; i < ARRAYSIZE(aes_tag_acc.data); i++) {
       aes_tag_acc.data[i] ^= aes_tag.data[i];
     }
   }
 
-  // Send accumulated CTX and TAG back to host.
-  aes_sca_block_t uj_ctx;
+  // Send accumulated TAG back to host.
   aes_sca_block_t uj_tag;
-
-  uj_ctx.num_valid_bytes = 16;
-  memset(uj_ctx.block, 0, sizeof(uj_ctx.block));
-  memcpy(uj_ctx.block, (uint8_t *)aes_ctx_acc.data, uj_ctx.num_valid_bytes);
-
   uj_tag.num_valid_bytes = 16;
   memset(uj_tag.block, 0, sizeof(uj_tag.block));
   memcpy(uj_tag.block, (uint8_t *)aes_tag_acc.data, uj_tag.num_valid_bytes);
 
-  RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_ctx);
   RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_tag);
 
   return OK_STATUS();
@@ -1031,26 +1016,18 @@ status_t handle_aes_sca_gcm_single_encrypt(ujson_t *uj) {
   }
 
   // Trigger the AES GCM operation.
-  dif_aes_data_t aes_ctx;
   dif_aes_data_t aes_tag;
   TRY(trigger_aes_gcm(key, aes_iv, aes_aad, uj_aad_blocks.num_blocks,
                       aes_aad_last_block_size, aes_ptx,
                       uj_ptx_blocks.num_blocks, aes_ptx_last_block_size,
-                      &aes_ctx, &aes_tag, uj_triggers));
+                      &aes_tag, uj_triggers));
 
-  // Send last CTX and TAG back to host.
-  aes_sca_block_t uj_ctx;
+  // Send TAG back to host.
   aes_sca_block_t uj_tag;
-
-  uj_ctx.num_valid_bytes = 16;
-  memset(uj_ctx.block, 0, sizeof(uj_ctx.block));
-  memcpy(uj_ctx.block, (uint8_t *)aes_ctx.data, uj_ctx.num_valid_bytes);
-
   uj_tag.num_valid_bytes = 16;
   memset(uj_tag.block, 0, sizeof(uj_tag.block));
   memcpy(uj_tag.block, (uint8_t *)aes_tag.data, uj_tag.num_valid_bytes);
 
-  RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_ctx);
   RESP_OK(ujson_serialize_aes_sca_block_t, uj, &uj_tag);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
@@ -242,6 +242,17 @@ status_t handle_aes_sca_fvsr_key_set(ujson_t *uj);
 status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj);
 
 /**
+ * AES-GCM FvsR Batch mode.
+ *
+ * IV and key are the FvsR data set.
+ * PTX and AAD always stays constant.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_sca_gcm_fvsr_batch(ujson_t *uj);
+
+/**
  * Invokes an AES-GCM encryption with tag generation.
  *
  * @param uj An initialized uJSON context.

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
@@ -242,6 +242,14 @@ status_t handle_aes_sca_fvsr_key_set(ujson_t *uj);
 status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj);
 
 /**
+ * Invokes an AES-GCM encryption with tag generation.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_sca_gcm_single_encrypt(ujson_t *uj);
+
+/**
  * Initialize AES command handler.
  *
  * This command is designed to setup the AES.

--- a/sw/device/tests/penetrationtests/json/aes_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/aes_sca_commands.h
@@ -75,7 +75,7 @@ UJSON_SERDE_STRUCT(CryptotestAesScaNumBlocks, aes_sca_num_blocks_t, AES_SCA_NUM_
 UJSON_SERDE_STRUCT(CryptotestAesScaBlock, aes_sca_block_t, AES_SCA_BLOCK);
 
 #define AES_SCA_GCM_TRIGGERS(field, string) \
-    field(triggers, bool, 4) \
+    field(triggers, bool, 5) \
     field(block, size_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaGcmTriggers, aes_sca_gcm_triggers_t, AES_SCA_GCM_TRIGGERS);
 

--- a/sw/device/tests/penetrationtests/json/aes_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/aes_sca_commands.h
@@ -13,6 +13,7 @@ extern "C" {
 #define AESSCA_CMD_MAX_KEY_BYTES 16
 #define AESSCA_CMD_MAX_LFSR_BYTES 4
 #define AESSCA_CMD_MAX_DATA_BYTES 16
+#define AESSCA_CMD_MAX_BLOCKS 1
 
 // clang-format off
 
@@ -28,6 +29,7 @@ extern "C" {
     value(_, FvsrKeyBatchGenerate) \
     value(_, FvsrKeySet) \
     value(_, FvsrKeyStartBatchGenerate) \
+    value(_, GcmSingleEncrypt) \
     value(_, Init) \
     value(_, KeySet) \
     value(_, SeedLfsr) \
@@ -61,6 +63,21 @@ UJSON_SERDE_STRUCT(CryptotestAesScaCiphertext, aes_sca_ciphertext_t, AES_SCA_CIP
 #define AES_SCA_FPGA_MODE(field, string) \
     field(fpga_mode, uint8_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaFpgaMode, aes_sca_fpga_mode_t, AES_SCA_FPGA_MODE);
+
+#define AES_SCA_NUM_BLOCKS(field, string) \
+    field(num_blocks, size_t)
+UJSON_SERDE_STRUCT(CryptotestAesScaNumBlocks, aes_sca_num_blocks_t, AES_SCA_NUM_BLOCKS);
+
+#define AES_SCA_BLOCK(field, string) \
+    field(block, uint8_t, AESSCA_CMD_MAX_DATA_BYTES) \
+    field(num_valid_bytes, size_t)
+UJSON_SERDE_STRUCT(CryptotestAesScaBlock, aes_sca_block_t, AES_SCA_BLOCK);
+
+#define AES_SCA_GCM_TRIGGERS(field, string) \
+    field(triggers, bool, 3) \
+    field(block, size_t)
+UJSON_SERDE_STRUCT(CryptotestAesScaGcmTriggers, aes_sca_gcm_triggers_t, AES_SCA_GCM_TRIGGERS);
+
 // clang-format on
 
 #ifdef __cplusplus

--- a/sw/device/tests/penetrationtests/json/aes_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/aes_sca_commands.h
@@ -75,7 +75,7 @@ UJSON_SERDE_STRUCT(CryptotestAesScaNumBlocks, aes_sca_num_blocks_t, AES_SCA_NUM_
 UJSON_SERDE_STRUCT(CryptotestAesScaBlock, aes_sca_block_t, AES_SCA_BLOCK);
 
 #define AES_SCA_GCM_TRIGGERS(field, string) \
-    field(triggers, bool, 3) \
+    field(triggers, bool, 4) \
     field(block, size_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaGcmTriggers, aes_sca_gcm_triggers_t, AES_SCA_GCM_TRIGGERS);
 

--- a/sw/device/tests/penetrationtests/json/aes_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/aes_sca_commands.h
@@ -29,6 +29,7 @@ extern "C" {
     value(_, FvsrKeyBatchGenerate) \
     value(_, FvsrKeySet) \
     value(_, FvsrKeyStartBatchGenerate) \
+    value(_, GcmFvsrBatch) \
     value(_, GcmSingleEncrypt) \
     value(_, Init) \
     value(_, KeySet) \
@@ -77,6 +78,10 @@ UJSON_SERDE_STRUCT(CryptotestAesScaBlock, aes_sca_block_t, AES_SCA_BLOCK);
     field(triggers, bool, 3) \
     field(block, size_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaGcmTriggers, aes_sca_gcm_triggers_t, AES_SCA_GCM_TRIGGERS);
+
+#define AES_SCA_NUM_OPS(field, string) \
+    field(num_batch_ops, size_t)
+UJSON_SERDE_STRUCT(CryptotestAesScaNumOps, aes_sca_num_ops_t, AES_SCA_NUM_OPS);
 
 // clang-format on
 


### PR DESCRIPTION
This commit extends the uJSON framework with the following two tests:

- Single AES-GCM operation. The device performs a single AES-GCM operation on a given input. The host can configure the number of AAD and PTX blocks as well as when the trigger pin gets asserted.
- Batch FvsR AES-GCM operation. A fixed vs. random set is executed N(=number of batch operations) times