### PR TITLE
[aes/rtl] Improve GCM initialization and status tracking controls

### DIFF
--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -33,6 +33,8 @@ module aes_control
   input  logic                      key_touch_forces_reseed_i,
   input  logic                      ctrl_gcm_qe_i,
   output logic                      ctrl_gcm_we_o,
+  input  logic                      ctrl_gcm_phase_i,
+  output logic                      gcm_init_done_o,
   input  gcm_phase_e                gcm_phase_i,
   input  logic                      start_i,
   input  logic                      key_iv_data_in_clear_i,
@@ -195,6 +197,7 @@ module aes_control
   // Multi-rail signals. These are outputs of the single-rail FSMs and need combining.
   logic          [Sp2VWidth-1:0] mr_ctrl_we;
   logic          [Sp2VWidth-1:0] mr_ctrl_gcm_we;
+  logic          [Sp2VWidth-1:0] mr_gcm_init_done;
   logic          [Sp2VWidth-1:0] mr_alert;
   logic          [Sp2VWidth-1:0] mr_data_in_we;
   data_out_sel_e [Sp2VWidth-1:0] mr_data_out_sel;
@@ -290,6 +293,8 @@ module aes_control
         .key_touch_forces_reseed_i ( key_touch_forces_reseed_i     ),
         .ctrl_gcm_qe_i             ( ctrl_gcm_qe_i                 ),
         .ctrl_gcm_we_o             ( mr_ctrl_gcm_we[i]             ), // AND-combine
+        .ctrl_gcm_phase_i          ( ctrl_gcm_phase_i              ),
+        .gcm_init_done_o           ( mr_gcm_init_done[i]           ), // AND-combine
         .gcm_phase_i               ( gcm_phase_i                   ),
         .start_i                   ( start_trigger                 ),
         .key_iv_data_in_clear_i    ( key_iv_data_in_clear_i        ),
@@ -392,6 +397,8 @@ module aes_control
         .key_touch_forces_reseed_i ( key_touch_forces_reseed_i     ),
         .ctrl_gcm_qe_i             ( ctrl_gcm_qe_i                 ),
         .ctrl_gcm_we_o             ( mr_ctrl_gcm_we[i]             ), // AND-combine
+        .ctrl_gcm_phase_i          ( ctrl_gcm_phase_i              ),
+        .gcm_init_done_o           ( mr_gcm_init_done[i]           ), // AND-combine
         .gcm_phase_i               ( gcm_phase_i                   ),
         .start_i                   ( start_trigger                 ),
         .key_iv_data_in_clear_i    ( key_iv_data_in_clear_i        ),
@@ -504,6 +511,7 @@ module aes_control
   // AND: Only if all bits are high, the corresponding action should be triggered.
   assign ctrl_we_o                 = &mr_ctrl_we;
   assign ctrl_gcm_we_o             = &mr_ctrl_gcm_we;
+  assign gcm_init_done_o           = &mr_gcm_init_done;
   assign data_in_we_o              = &mr_data_in_we;
   assign key_iv_data_in_clear_we_o = &mr_key_iv_data_in_clear_we;
   assign data_out_clear_we_o       = &mr_data_out_clear_we;

--- a/hw/ip/aes/rtl/aes_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_n.sv
@@ -38,6 +38,8 @@ module aes_control_fsm_n
   input  logic                                    key_touch_forces_reseed_i,
   input  logic                                    ctrl_gcm_qe_i,
   output logic                                    ctrl_gcm_we_o,
+  input  logic                                    ctrl_gcm_phase_i,
+  output logic                                    gcm_init_done_o,
   input  gcm_phase_e                              gcm_phase_i,
   input  logic                                    start_i,
   input  logic                                    key_iv_data_in_clear_i,
@@ -147,6 +149,7 @@ module aes_control_fsm_n
     manual_operation_i,
     key_touch_forces_reseed_i,
     ctrl_gcm_qe_i,
+    ctrl_gcm_phase_i,
     gcm_phase_i,
     start_i,
     key_iv_data_in_clear_i,
@@ -190,6 +193,7 @@ module aes_control_fsm_n
     manual_operation_i,
     key_touch_forces_reseed_i,
     ctrl_gcm_qe_i,
+    ctrl_gcm_phase_i,
     gcm_phase_i,
     start_i,
     key_iv_data_in_clear_i,
@@ -240,6 +244,7 @@ module aes_control_fsm_n
   logic                                    manual_operation;
   logic                                    key_touch_forces_reseed;
   logic                                    ctrl_gcm_qe;
+  logic                                    ctrl_gcm_phase;
   gcm_phase_e                              gcm_phase;
   logic             [$bits(gcm_phase)-1:0] gcm_phase_raw;
   logic                                    start;
@@ -280,6 +285,7 @@ module aes_control_fsm_n
           manual_operation,
           key_touch_forces_reseed,
           ctrl_gcm_qe,
+          ctrl_gcm_phase,
           gcm_phase_raw,
           start,
           key_iv_data_in_clear,
@@ -314,6 +320,7 @@ module aes_control_fsm_n
   // Intermediate output signals
   logic                                    ctrl_we;
   logic                                    ctrl_gcm_we;
+  logic                                    gcm_init_done;
   logic                                    alert;
   logic                                    data_in_we;
   data_out_sel_e                           data_out_sel;
@@ -385,6 +392,8 @@ module aes_control_fsm_n
     .key_touch_forces_reseed_i ( key_touch_forces_reseed       ),
     .ctrl_gcm_qe_i             ( ctrl_gcm_qe                   ),
     .ctrl_gcm_we_o             ( ctrl_gcm_we                   ),
+    .ctrl_gcm_phase_i          ( ctrl_gcm_phase                ),
+    .gcm_init_done_o           ( gcm_init_done                 ),
     .gcm_phase_i               ( gcm_phase                     ),
     .start_i                   ( start                         ),
     .key_iv_data_in_clear_i    ( key_iv_data_in_clear          ),
@@ -474,6 +483,7 @@ module aes_control_fsm_n
   localparam int NumOutBufBits = $bits({
     ctrl_we_o,
     ctrl_gcm_we_o,
+    gcm_init_done_o,
     alert_o,
     data_in_we_o,
     data_out_sel_o,
@@ -525,6 +535,7 @@ module aes_control_fsm_n
   assign out = {
     ctrl_we,
     ctrl_gcm_we,
+    gcm_init_done,
     alert,
     data_in_we,
     data_out_sel,
@@ -580,6 +591,7 @@ module aes_control_fsm_n
 
   assign {ctrl_we_o,
           ctrl_gcm_we_o,
+          gcm_init_done_o,
           alert_o,
           data_in_we_o,
           data_out_sel_o,

--- a/hw/ip/aes/rtl/aes_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_p.sv
@@ -34,6 +34,8 @@ module aes_control_fsm_p
   input  logic                                    key_touch_forces_reseed_i,
   input  logic                                    ctrl_gcm_qe_i,
   output logic                                    ctrl_gcm_we_o,
+  input  logic                                    ctrl_gcm_phase_i,
+  output logic                                    gcm_init_done_o,
   input  gcm_phase_e                              gcm_phase_i,
   input  logic                                    start_i,
   input  logic                                    key_iv_data_in_clear_i,
@@ -143,6 +145,7 @@ module aes_control_fsm_p
     manual_operation_i,
     key_touch_forces_reseed_i,
     ctrl_gcm_qe_i,
+    ctrl_gcm_phase_i,
     gcm_phase_i,
     start_i,
     key_iv_data_in_clear_i,
@@ -186,6 +189,7 @@ module aes_control_fsm_p
     manual_operation_i,
     key_touch_forces_reseed_i,
     ctrl_gcm_qe_i,
+    ctrl_gcm_phase_i,
     gcm_phase_i,
     start_i,
     key_iv_data_in_clear_i,
@@ -236,6 +240,7 @@ module aes_control_fsm_p
   logic                                    manual_operation;
   logic                                    key_touch_forces_reseed;
   logic                                    ctrl_gcm_qe;
+  logic                                    ctrl_gcm_phase;
   gcm_phase_e                              gcm_phase;
   logic             [$bits(gcm_phase)-1:0] gcm_phase_raw;
   logic                                    start;
@@ -276,6 +281,7 @@ module aes_control_fsm_p
           manual_operation,
           key_touch_forces_reseed,
           ctrl_gcm_qe,
+          ctrl_gcm_phase,
           gcm_phase_raw,
           start,
           key_iv_data_in_clear,
@@ -310,6 +316,7 @@ module aes_control_fsm_p
   // Intermediate output signals
   logic                                    ctrl_we;
   logic                                    ctrl_gcm_we;
+  logic                                    gcm_init_done;
   logic                                    alert;
   logic                                    data_in_we;
   data_out_sel_e                           data_out_sel;
@@ -377,6 +384,8 @@ module aes_control_fsm_p
     .key_touch_forces_reseed_i ( key_touch_forces_reseed       ),
     .ctrl_gcm_qe_i             ( ctrl_gcm_qe                   ),
     .ctrl_gcm_we_o             ( ctrl_gcm_we                   ),
+    .ctrl_gcm_phase_i          ( ctrl_gcm_phase                ),
+    .gcm_init_done_o           ( gcm_init_done                 ),
     .gcm_phase_i               ( gcm_phase                     ),
     .start_i                   ( start                         ),
     .key_iv_data_in_clear_i    ( key_iv_data_in_clear          ),
@@ -466,6 +475,7 @@ module aes_control_fsm_p
   localparam int NumOutBufBits = $bits({
     ctrl_we_o,
     ctrl_gcm_we_o,
+    gcm_init_done_o,
     alert_o,
     data_in_we_o,
     data_out_sel_o,
@@ -515,6 +525,7 @@ module aes_control_fsm_p
   assign out = {
     ctrl_we,
     ctrl_gcm_we,
+    gcm_init_done,
     alert,
     data_in_we,
     data_out_sel,
@@ -570,6 +581,7 @@ module aes_control_fsm_p
 
   assign {ctrl_we_o,
           ctrl_gcm_we_o,
+          gcm_init_done_o,
           alert_o,
           data_in_we_o,
           data_out_sel_o,

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -73,6 +73,8 @@ module aes_core
   logic                                       ctrl_reg_err_storage;
   logic                                       ctrl_gcm_qe;
   logic                                       ctrl_gcm_we;
+  logic                                       ctrl_gcm_phase;
+  logic                                       gcm_init_done;
   gcm_phase_e                                 gcm_phase_q;
   logic                                 [4:0] num_valid_bytes_q;
   logic                                       ctrl_gcm_reg_err_update;
@@ -688,6 +690,8 @@ module aes_core
     .rst_shadowed_ni    ( rst_shadowed_ni          ),
     .qe_o               ( ctrl_gcm_qe              ),
     .we_i               ( ctrl_gcm_we              ),
+    .phase_o            ( ctrl_gcm_phase           ),
+    .init_done_i        ( gcm_init_done            ),
     .first_block_i      ( ghash_first_block        ),
     .gcm_phase_o        ( gcm_phase_q              ),
     .num_valid_bytes_o  ( num_valid_bytes_q        ),
@@ -723,6 +727,8 @@ module aes_core
     .key_touch_forces_reseed_i ( key_touch_forces_reseed                ),
     .ctrl_gcm_qe_i             ( ctrl_gcm_qe                            ),
     .ctrl_gcm_we_o             ( ctrl_gcm_we                            ),
+    .ctrl_gcm_phase_i          ( ctrl_gcm_phase                         ),
+    .gcm_init_done_o           ( gcm_init_done                          ),
     .gcm_phase_i               ( gcm_phase_q                            ),
     .start_i                   ( reg2hw.trigger.start.q                 ),
     .key_iv_data_in_clear_i    ( reg2hw.trigger.key_iv_data_in_clear.q  ),


### PR DESCRIPTION
This commit implements two changes related to the initialization phase of GCM:

1. GCM-specific status tracking is now cleared after every second write to the shadowed GCM control register. This also holds for the IV status tracking in case GCM is configured. Previously, it was possible to (abort a GCM message and) start a new GCM message without going through the proper intialization.

2. The initialization phase cannot be left (by writing the shadowed GCM control register) unless both the hash subkey and the encrypted initial counter block have been loaded into the GHASH block. This is particularly relevant for manual mode operation where software has to explicitly trigger two AES encryptions for the initialization.