### PR TITLE
[aes] Sign off at D2S/V2S for v.1.1.0 including AES-GCM

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -24,8 +24,8 @@
   sw_checklist:       "/sw/device/lib/dif/dif_aes",
   version:            "1.1.0",
   life_stage:         "L1",
-  design_stage:       "D1",
-  verification_stage: "V1",
+  design_stage:       "D2S",
+  verification_stage: "V2S",
   dif_stage:          "S2",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", idle: "idle_o", primary: true},

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -76,7 +76,7 @@ Security      | [SEC_CM_DOCUMENTED][]     | Done        |
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
 Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
-Security      | [SEC_CM_IMPLEMENTED][]       | Done        | Datapath FI hardening in progress (not strictly required)
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | Datapath FI hardening and multi-rail GHASH FSM implementation not strictly required, these may get added later
 Security      | [SEC_CM_RND_CNST][]          | Done        |
 Security      | [SEC_CM_NON_RESET_FLOPS][]   | Done        |
 Security      | [SEC_CM_SHADOW_REGS][]       | Done        |


### PR DESCRIPTION
According to the reviewed sign-off documents:
- [AES GCM D2 & D2S Signoff](https://docs.google.com/document/d/1nFxnC3e1FStqpkFBxRGJvwiQzXbcqwHZGuG2-UzPpAk/edit?tab=t.0#heading=h.1qclayvn47ln)
- [AES GCM V2 & V2S Signoff](https://docs.google.com/document/d/1c7SJFMVWN4DfMA83gPvQyFvl84Yt_JsxG_IOjUOIr-M/edit?tab=t.0)

For a detailed report of the DV status, refer to [this doc](https://docs.google.com/document/d/16I71iHlFUWxBJbArvPy4C-9N6iNq2dGl5qetfBoxrAo/edit?tab=t.0).